### PR TITLE
Refactored shortcutEnter to shortcutEscape to remove ambiguity.

### DIFF
--- a/iterate_features.py
+++ b/iterate_features.py
@@ -47,9 +47,9 @@ def spaceBarPressed():
         print "We reached the last feature of this layer already.\n" + \
             "If you want to restart press the Escape key."
     
-shortcutEnter = QShortcut(QKeySequence(Qt.Key_Escape), iface.mapCanvas())
-shortcutEnter.setContext(Qt.ApplicationShortcut)
-shortcutEnter.activated.connect(escapePressed)
+shortcutEscape = QShortcut(QKeySequence(Qt.Key_Escape), iface.mapCanvas())
+shortcutEscape.setContext(Qt.ApplicationShortcut)
+shortcutEscape.activated.connect(escapePressed)
 
 shortcutSpaceBar = QShortcut(QKeySequence(Qt.Key_Space), iface.mapCanvas())
 shortcutSpaceBar.setContext(Qt.ApplicationShortcut)


### PR DESCRIPTION
Renaming shortcutEnter to shortcutEscape would seem more logical, since it refers to pressing the Escape key and not the Enter key.